### PR TITLE
docs(README): fix badge links for new repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# hoodie-server-account
+# hoodie-account-server
 
 > Account REST API backed by CouchDB
 
-[![Build Status](https://api.travis-ci.org/hoodiehq/hoodie-server-account.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie-server-account)
-[![Dependency Status](https://david-dm.org/hoodiehq/hoodie-server-account.svg)](https://david-dm.org/hoodiehq/hoodie-account-server)
-[![devDependency Status](https://david-dm.org/hoodiehq/hoodie-server-account/dev-status.svg)](https://david-dm.org/hoodiehq/hoodie-server-account#info=devDependencies)
+[![Build Status](https://api.travis-ci.org/hoodiehq/hoodie-account-server.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie-account-server)
+[![Dependency Status](https://david-dm.org/hoodiehq/hoodie-account-server.svg)](https://david-dm.org/hoodiehq/hoodie-account-server)
+[![devDependency Status](https://david-dm.org/hoodiehq/hoodie-account-server/dev-status.svg)](https://david-dm.org/hoodiehq/hoodie-account-server#info=devDependencies)
 ✷
 
-✷ coverage is currently disabled: [#37](https://github.com/hoodiehq/hoodie-server-account/issues/37)
+✷ coverage is currently disabled: [#37](https://github.com/hoodiehq/hoodie-account-server/issues/37)
 
 ## Usage
 


### PR DESCRIPTION
Fix links.

The fix in #134 was too fast for the caches to catch up I guess :grinning: 