### PR TITLE
Issue/37 fix and re-enable coverage and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@
 > Account REST API backed by CouchDB
 
 [![Build Status](https://api.travis-ci.org/hoodiehq/hoodie-account-server.svg?branch=master)](https://travis-ci.org/hoodiehq/hoodie-account-server)
+[![Coverage Status](https://coveralls.io/repos/hoodiehq/hoodie-server-account/badge.svg?branch=master)](https://coveralls.io/r/hoodiehq/hoodie-server-account?branch=master)
 [![Dependency Status](https://david-dm.org/hoodiehq/hoodie-account-server.svg)](https://david-dm.org/hoodiehq/hoodie-account-server)
 [![devDependency Status](https://david-dm.org/hoodiehq/hoodie-account-server/dev-status.svg)](https://david-dm.org/hoodiehq/hoodie-account-server#info=devDependencies)
-✷
-
-✷ coverage is currently disabled: [#37](https://github.com/hoodiehq/hoodie-account-server/issues/37)
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,21 @@
   "description": "Account REST API backed by CouchDB",
   "main": "plugin/index.js",
   "scripts": {
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "start": "bin/server",
     "pretest": "standard",
-    "test": "tap tests/{unit,integration}/{**,**/**}/*-test.js",
+    "test": "nyc tap tests/{unit,integration}/{**,**/**}/*-test.js",
     "test:watch": "gaze 'bin/watch-and-test.sh $path' 'tests/**/*.js' '*.js' 'api/**/*.js' 'plugin/**/*.js' 'routes/**/*.js' 'utils/**/*.js'",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "postsemantic-release": "npm run coverage"
+  },
+  "nyc": {
+    "//": "don't let nyc instrument users-design-doc.js because it will be executed inside PouchDB",
+    "//": "since we override the default excludes, we have to also (re)exclude the tests directory",
+    "exclude": [
+      "tests",
+      "plugin/couchdb/users-design-doc.js"
+    ]
   },
   "repository": {
     "type": "git",
@@ -35,6 +45,7 @@
     "memdown": "^1.1.2",
     "nock": "^7.0.2",
     "nodemailer-stub-transport": "^1.0.0",
+    "nyc": "^6.0.0",
     "pouchdb": "^5.2.0",
     "pouchdb-users": "^1.0.3",
     "semantic-release": "^6.1.0",
@@ -51,7 +62,6 @@
     "joi": "^8.0.1",
     "lodash": "^4.0.1",
     "nodemailer": "^2.0.0",
-    "nyc": "^6.0.0",
     "pouchdb-admins": "^1.0.0",
     "randomstring": "^1.1.3",
     "request": "^2.69.0"

--- a/tests/integration/api/accounts-test.js
+++ b/tests/integration/api/accounts-test.js
@@ -3,7 +3,7 @@ var PouchDB = require('pouchdb').defaults({
 })
 var test = require('tap').test
 
-var usersDesignDoc = require('../../../plugin/couchdb/users-design-doc.js')
+var usersDesignDoc = require('../../../plugin/couchdb/users-design-doc')
 var getApi = require('../../../api')
 
 PouchDB.plugin(require('pouchdb-users'))


### PR DESCRIPTION
fixes #37 
reverts commits fef841676380fe80c42a7dc627f55e8ec76c99fb and d8a5f87c520e3c72586358a1fb9fefb18e05d076

The coverage is now working. The problem was `plugin/couchdb/users-design-doc.js` was being instrumented and then put into PouchDB as a view (as part of the test setup). The instrumented map function of the view was then called inside of PouchDB with (from the perspective of PouchDB) garbage code (instrumented code).

To fix the problem, I added an exclude to the nyc config in `package.json` to not instrument the file. As noted in my comments, the `tests` directory had to manually added to the excludes because we are now overriding the default excludes (see [nyc.js README](https://github.com/bcoe/nyc#excluding-files)).

Note: I'm not sure how to test with coveralls or the badge (but running npm test now includes the coverage report). However, I reverted all of the changes from the two mentioned commits.

Please review and don't hesitate to purpose a more elegant solution.