### PR TITLE
chore: refactor error checking to use status codes where possible

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -73,23 +73,26 @@ function accountRoutes (server, options, next) {
       // check for admin. If not found, check for user
       admins.validateSession(sessionId)
 
-      .then(function (doc) {
-        throw errors.NO_ADMIN_ACCOUNT
-      })
+      .then(
+        // if admin
+        function (doc) {
+          throw errors.NO_ADMIN_ACCOUNT
+        },
 
-      .catch(function (error) {
-        if (error.name === 'not_found') {
-          return sessions.find(sessionId, {
-            include: request.query.include === 'profile' ? 'account.profile' : undefined
-          }).catch(function (error) {
-            if (error.status === 404) {
-              throw errors.INVALID_SESSION
-            }
-          })
-        }
+        // if not admin
+        function (error) {
+          if (error.status === 404) {
+            return sessions.find(sessionId, {
+              include: request.query.include === 'profile' ? 'account.profile' : undefined
+            }).catch(function (error) {
+              if (error.status === 404) {
+                throw errors.INVALID_SESSION
+              }
+            })
+          }
 
-        throw error
-      })
+          throw error
+        })
 
       .then(function (session) {
         return session.account
@@ -126,21 +129,24 @@ function accountRoutes (server, options, next) {
       var id = request.payload.data.id
 
       admins.validateSession(sessionId)
-      .then(function (doc) {
-        throw errors.FORBIDDEN_ADMIN_ACCOUNT
-      })
+      .then(
+        // if admin
+        function (doc) {
+          throw errors.FORBIDDEN_ADMIN_ACCOUNT
+        },
 
-      .catch(function (error) {
-        if (error.name === 'not_found') {
-          return sessions.find(sessionId)
-            .catch(function (error) {
-              if (error.status === 404) {
-                throw errors.INVALID_SESSION
-              }
-            })
-        }
-        throw error
-      })
+        // if not admin
+        function (error) {
+          if (error.status === 404) {
+            return sessions.find(sessionId)
+              .catch(function (error) {
+                if (error.status === 404) {
+                  throw errors.INVALID_SESSION
+                }
+              })
+          }
+          throw error
+        })
 
       .then(function (session) {
         if (session.account.id !== id) {
@@ -182,23 +188,26 @@ function accountRoutes (server, options, next) {
       // check for admin. If not found, check for user
       admins.validateSession(sessionId)
 
-      .then(function (doc) {
-        throw errors.FORBIDDEN_ADMIN_ACCOUNT
-      })
+      .then(
+        // if admin
+        function (doc) {
+          throw errors.FORBIDDEN_ADMIN_ACCOUNT
+        },
 
-      .catch(function (error) {
-        if (error.name === 'not_found') {
-          return sessions.find(sessionId, {
-            include: request.query.include === 'profile' ? 'account.profile' : undefined
-          }).catch(function (error) {
-            if (error.status === 404) {
-              throw errors.INVALID_SESSION
-            }
-          })
-        }
+        // if not admin
+        function (error) {
+          if (error.status === 404) {
+            return sessions.find(sessionId, {
+              include: request.query.include === 'profile' ? 'account.profile' : undefined
+            }).catch(function (error) {
+              if (error.status === 404) {
+                throw errors.INVALID_SESSION
+              }
+            })
+          }
 
-        throw error
-      })
+          throw error
+        })
 
       .then(function (session) {
         return accounts.remove(session.account, {

--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -57,7 +57,7 @@ function accountRoutes (server, options, next) {
       })
 
       .catch(function (error) {
-        if (error.message === 'Name or password is incorrect.') {
+        if (error.status === 401) {
           error.message = 'Session invalid'
         }
         if (error.message === 'missing') {

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -36,24 +36,27 @@ function profileRoutes (server, options, next) {
       // check for admin. If not found, check for user
       admins.validateSession(sessionId)
 
-      .then(function (doc) {
-        throw errors.NO_PROFILE_ACCOUNT
-      })
+      .then(
+        // if admin
+        function (doc) {
+          throw errors.NO_PROFILE_ACCOUNT
+        },
 
-      .catch(function (error) {
-        if (error.name === 'not_found') {
-          return sessions.find(sessionId, {
-            include: 'account.profile'
-          })
-          .catch(function (error) {
-            if (error.status === 404) {
-              throw errors.INVALID_SESSION
-            }
-          })
-        }
+        // if not admin
+        function (error) {
+          if (error.status === 404) {
+            return sessions.find(sessionId, {
+              include: 'account.profile'
+            })
+            .catch(function (error) {
+              if (error.status === 404) {
+                throw errors.INVALID_SESSION
+              }
+            })
+          }
 
-        throw error
-      })
+          throw error
+        })
 
       .then(function (session) {
         return session.account
@@ -90,24 +93,27 @@ function profileRoutes (server, options, next) {
       // check for admin. If not found, check for user
       admins.validateSession(sessionId)
 
-        .then(function (doc) {
-          throw errors.NO_PROFILE_ACCOUNT
-        })
+        .then(
+          // if admin
+          function (doc) {
+            throw errors.NO_PROFILE_ACCOUNT
+          },
 
-        .catch(function (error) {
-          if (error.name === 'not_found') {
-            return sessions.find(sessionId, {
-              include: 'account.profile'
-            })
-              .catch(function (error) {
-                if (error.status === 404) {
-                  throw errors.INVALID_SESSION
-                }
+          // if not admin
+          function (error) {
+            if (error.status === 404) {
+              return sessions.find(sessionId, {
+                include: 'account.profile'
               })
-          }
+                .catch(function (error) {
+                  if (error.status === 404) {
+                    throw errors.INVALID_SESSION
+                  }
+                })
+            }
 
-          throw error
-        })
+            throw error
+          })
 
         .then(function (session) {
           if (session.account.id + '-profile' !== id) {


### PR DESCRIPTION
As described in #147 this PR refactors the error checking to use the status code when possible in an effort to standardize the error handling.

To achieve this, I am also using the pattern of providing a function for _both_ parameters in the [then() prototype of Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then). This allows the code to be cleaner in the cases when resolving a promise is actually an error condition (see account.js below). Before, we could not compare the status code and needed to compare the message because the catch handler was always executed. The pattern provides cleaner separation of error and success cases IMO. Thanks to @tdd for presenting this pattern in his amazing js training that I attended.