### PR TITLE
Api.session.add

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -151,7 +151,7 @@ admin.sessions.add(options)
   <tr>
     <th align="left"><code>options.auth</code></th>
     <td>Object</td>
-    <td>Can be <code>username</code> and <code>password</code> or <code>session</code>. If not set, will use <code>options.auth</code> from <a href="#constructor">Constructor</a></td>
+    <td>Object with property <code>password</code>, a String that will be validated in the user document. If not included, admin access is assumed (no authentication)</td>
     <td>No</td>
   </tr>
 </table>

--- a/api/sessions/add.js
+++ b/api/sessions/add.js
@@ -10,9 +10,14 @@ function addSession (state, options) {
   return state.db.get('org.couchdb.user:' + options.username)
 
   .then(function (doc) {
+    // no auth, skip authentication (act as admin)
+    if (!options.auth) {
+      return doc
+    }
+
     return new Promise(function (resolve, reject) {
       validatePassword(
-        options.password,
+        options.auth.password,
         doc.salt,
         doc.iterations,
         doc.derived_key,

--- a/routes/session.js
+++ b/routes/session.js
@@ -59,7 +59,9 @@ function sessionRoutes (server, options, next) {
           if (error.status === 404) {
             return sessions.add({
               username: username,
-              password: password,
+              auth: {
+                password: password
+              },
               include: query.include
             })
             .catch(function (error) {


### PR DESCRIPTION
Fixes #26 as discussed in the issue and briefly with @gr2m on slack:
> We can make `auth` optional. If it’s not set, then we simply create a new session id for the given username

I updated the api doc to match the implementation. Is that OK and your intention? If yes, this is ready to go...

Final note: there are not really any unit tests for session handling. The functionality is tested in integration tests. So when I made the auth param optional, it won't be tested until I finish #80 