### PR TITLE
options.PouchDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,31 +19,25 @@ var Hapi = require('hapi')
 var PouchDB = require('PouchDB')
 var hapiAccount = require('@hoodie/account-server')
 
-PouchDB.plugin(require('pouchdb-users'))
-
-var db = new PouchDB('http://localhost:5984/_users')
-db.installUsersBehavior().then(function () {
-  var options = {
-    usersDb: db,
-    admins: {
-      admin: '-pbkdf2-a2ca9d3ee921c26d2e9d61e03a0801b11b8725c6,1081b31861bd1e91611341da16c11c16a12c13718d1f712e,10'
-    },
-    secret: 'secret123'
-  })
-
-  server.register({register: hapiAccount, options: options}, function (error) {});
-  server.connection({ port: 8000 });
-  server.start(function () {
-    console.log('Server running at %s', server.info.uri);
-  });
+var options = {
+  PouchDB: PouchDB,
+  admins: {
+    admin: '-pbkdf2-a2ca9d3ee921c26d2e9d61e03a0801b11b8725c6,1081b31861bd1e91611341da16c11c16a12c13718d1f712e,10'
+  },
+  secret: 'secret123'
 })
+
+server.register({register: hapiAccount, options: options}, function (error) {});
+server.connection({ port: 8000 });
+server.start(function () {
+  console.log('Server running at %s', server.info.uri);
+});
 ```
 
 ## More
 
 - [Plugin & Options](plugin/README.md)
 - [Routes](routes/README.md)
-- [API](api/README.md)
 - [How it works](how-it-works.md)
 - [Testing](tests/README.md)
 

--- a/package.json
+++ b/package.json
@@ -48,14 +48,13 @@
     "nodemailer-stub-transport": "^1.0.0",
     "nyc": "^8.1.0",
     "pouchdb": "^6.0.5",
-    "pouchdb-users": "^1.0.3",
     "semantic-release": "^6.1.0",
     "standard": "^8.0.0",
     "tap": "^7.0.0"
   },
   "dependencies": {
     "@gar/hapi-json-api": "^2.0.1",
-    "@hoodie/account-server-api": "^1.0.0",
+    "@hoodie/account-server-api": "^2.0.0",
     "base64url": "^2.0.0",
     "boom": "^4.0.0",
     "couchdb-calculate-session-id": "^1.1.0",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -2,7 +2,7 @@
 
 # hapi CouchDB Account Plugin
 
-Exposes a [REST API](../routes/README.md) and [JavaScript API](../api/README.md) at
+Exposes a [REST API](../routes/README.md) and [JavaScript API](https://github.com/hoodiehq/hoodie-account-server-api) at
 `server.plugins.account.api`.
 
 This plugin also creates `_users/_design/byId` in your CouchDB, which has one
@@ -15,11 +15,11 @@ var Hapi = require('hapi')
 var hapiAccount = require('@hoodie/account-server')
 
 var PouchDB = require('pouchdb')
-PouchDB.plugin(require('pouchdb-users'))
-PouchDB.plugin(require('pouchdb-admins'))
+  .plugin(require('pouchdb-admins'))
 
-var db = new PouchDB('http://localhost:5984/_users')
 var options = {
+  PouchDB: PouchDB,
+  usersDb: 'my-users-db',
   admins: {
     admin: '-pbkdf2-a2ca9d3ee921c26d2e9d61e03a0801b11b8725c6,1081b31861bd1e91611341da16c11c16a12c13718d1f712e,10'
   },
@@ -71,37 +71,35 @@ var options = {
   }
 })
 
-db.useAsAuthenticationDB().then(function () {
-  options.usersDb = db
+server.register({
+  register: hapiAccount,
+  options: options
+}, function (error) {
+  if (error) {
+    throw error
+  }
 
-  server.register({
-    register: hapiAccount,
-    options: options
-  }, function (error) {
-    if (error) {
-      throw error
-    }
+  // plugin account api, see below
+});
 
-    // plugin account api, see below
-  });
+server.connection({
+  port: 8000
+});
 
-  server.connection({
-    port: 8000
-  });
-
-  server.start(function () {
-    console.log('Server running at %s', server.info.uri);
-  });
-})
+server.start(function () {
+  console.log('Server running at %s', server.info.uri);
+});
 ```
 
 ## Options
 
+### options.PouchDB
+
+[PouchDB](https://pouchdb.com/) constructor
+
 ### options.usersDb
 
-PouchDB instance with the
-[pouchdb-users](https://github.com/hoodiehq/pouchdb-users) and
-[pouchdb-admins](https://github.com/hoodiehq/pouchdb-admins) plugin.
+Name of users database. Defaults to `_users`
 
 ### options.admins
 

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -3,9 +3,9 @@ hapiAccount.attributes = {
   name: 'account'
 }
 
-// var getApi = require('../api')
-var getApi = require('@hoodie/account-server-api')
 var _ = require('lodash')
+var admins = require('pouchdb-admins').admins
+var getApi = require('@hoodie/account-server-api')
 
 var routePlugins = [
   require('../routes/account'),
@@ -20,14 +20,13 @@ function hapiAccount (server, options, next) {
   var routeOptions = _.cloneDeep({}, options)
   routeOptions.sessionTimeout = options.sessionTimeout || TIMEOUT_14_DAYS
 
-  options.usersDb.constructor.plugin(require('pouchdb-admins'))
-
   var users = getApi({
-    db: options.usersDb,
+    PouchDB: options.PouchDB,
+    usersDb: options.usersDb,
     secret: options.secret,
     sessionTimeout: routeOptions.sessionTimeout
   })
-  routeOptions.admins = options.usersDb.admins({
+  routeOptions.admins = admins({
     secret: options.secret,
     admins: options.admins,
     sessionTimeout: routeOptions.sessionTimeout

--- a/tests/integration/utils/get-server.js
+++ b/tests/integration/utils/get-server.js
@@ -3,7 +3,9 @@ module.exports = getServer
 var defaults = require('lodash/defaultsDeep')
 var Hapi = require('hapi')
 var nock = require('nock')
-var PouchDB = require('pouchdb')
+var PouchDB = require('pouchdb').defaults({
+  prefix: 'http://localhost:5984/'
+})
 
 var hapiAccount = require('../../../plugin')
 
@@ -31,26 +33,19 @@ function getServer (options, callback) {
     .put('/_users/_design/byId')
     .reply(201)
 
-  PouchDB.plugin(require('pouchdb-users'))
-
-  var usersDb = new PouchDB('http://localhost:5984/_users')
-  usersDb.installUsersBehavior()
-  .then(function () {
-    server.register({
-      register: hapiAccount,
-      options: defaults({
-        usersDb: usersDb,
-        secret: 'secret',
-        admins: {
-          // -<password scheme>-<derived key>,<salt>,<iterations>
-          // password is "secret"
-          admin: '-pbkdf2-a2ca9d3ee921c26d2e9d61e03a0801b11b8725c6,1081b31861bd1e91611341da16c11c16a12c13718d1f712e,10'
-        },
-        notifications: {}
-      }, options)
-    }, function (error) {
-      callback(error, server)
-    })
+  server.register({
+    register: hapiAccount,
+    options: defaults({
+      PouchDB: PouchDB,
+      secret: 'secret',
+      admins: {
+        // -<password scheme>-<derived key>,<salt>,<iterations>
+        // password is "secret"
+        admin: '-pbkdf2-a2ca9d3ee921c26d2e9d61e03a0801b11b8725c6,1081b31861bd1e91611341da16c11c16a12c13718d1f712e,10'
+      },
+      notifications: {}
+    }, options)
+  }, function (error) {
+    callback(error, server)
   })
-  .catch(callback)
 }


### PR DESCRIPTION
This is a follow up for https://github.com/hoodiehq/hoodie-account-server-api/pull/2

Before, `options.usersDb` was passed, pre-initialised with `pouchdb-users`:

```js
var Hapi = require("hapi")
var PouchDB = require("PouchDB")
var hapiAccount = require("@hoodie/account-server")

PouchDB.plugin(require("pouchdb-users"))

var db = new PouchDB("http://localhost:5984/_users")
db.installUsersBehavior().then(function () {
  var options = {
    usersDb: db,
    admins: {
      admin: "-pbkdf2-a2ca9d3ee921c26d2e9d61e03a0801b11b8725c6,1081b31861bd1e91611341da16c11c16a12c13718d1f712e,10"
    },
    secret: "secret123"
  })

  server.register({register: hapiAccount, options: options}, function (error) {});
  server.connection({ port: 8000 });
  server.start(function () {
    console.log("Server running at %s", server.info.uri);
  });
})
```

Now, `options.PouchDB` and optionally `options.usersDb` which is only the database name (defaults to `_users`) are passed:

```js
var Hapi = require("hapi")
var PouchDB = require("PouchDB")
var hapiAccount = require("@hoodie/account-server")

var options = {
  PouchDB: PouchDB,
  admins: {
    admin: "-pbkdf2-a2ca9d3ee921c26d2e9d61e03a0801b11b8725c6,1081b31861bd1e91611341da16c11c16a12c13718d1f712e,10"
  },
  secret: "secret123"
})

server.register({register: hapiAccount, options: options}, function (error) {})
server.connection({ port: 8000 })
server.start(function () {
  console.log("Server running at %s", server.info.uri)
})
```