### PR TITLE
test(routes): GET /accounts?include=foobar

### DIFF
--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -77,6 +77,7 @@ function accountRoutes (server, options, next) {
       auth: false,
       validate: {
         headers: validations.sessionIdHeader,
+        query: validations.accountQuery,
         failAction: joiFailAction
       }
     },

--- a/tests/integration/routes/accounts/get-accounts-test.js
+++ b/tests/integration/routes/accounts/get-accounts-test.js
@@ -155,8 +155,16 @@ getServer(function (error, server) {
       })
     })
 
-    group.test('with ?include=foobar', {todo: true}, function (t) {
-      t.end()
+    group.test('with ?include=foobar', function (t) {
+      var options = _.defaultsDeep({
+        url: '/accounts?include=foobar'
+      }, routeOptions)
+
+      server.inject(options, function (response) {
+        t.is(response.statusCode, 400, 'returns 400 status')
+        t.deepEqual(response.result.errors[0].detail, 'Allowed value for ?include is \'profile\'', 'returns error message')
+        t.end()
+      })
     })
 
     couchdbErrorTests(server, group, mockCouchDbGetAccounts, routeOptions)


### PR DESCRIPTION
closes hoodiehq/camp#63