### PR TITLE
test(routes): GET /accounts/{id} with invalid session

### DIFF
--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -132,9 +132,22 @@ function accountRoutes (server, options, next) {
     handler: function (request, reply) {
       var sessionId = toSessionId(request)
 
-      return accounts.find(request.params.id, {
-        sessionId: sessionId,
-        include: request.query.include
+      admins.validateSession(sessionId)
+
+      .catch(function (error) {
+        // pouchdb-admins throws MISSING_DOC with status 404 if the admin doc is not found
+        if (error.status === 404) {
+          throw errors.INVALID_SESSION
+        }
+
+        throw error
+      })
+
+      .then(function () {
+        return accounts.find(request.params.id, {
+          sessionId: sessionId,
+          include: request.query.include
+        })
       })
 
       .then(function (account) {

--- a/routes/session.js
+++ b/routes/session.js
@@ -190,7 +190,7 @@ function sessionRoutes (server, options, next) {
         })
 
       .then(function (session) {
-        if (!session) {
+        if (!request.query.include) {
           return reply().code(204)
         }
         reply(serialise(session)).code(200)

--- a/tests/integration/routes/accounts/get-accounts-test.js
+++ b/tests/integration/routes/accounts/get-accounts-test.js
@@ -267,8 +267,20 @@ getServer(function (error, server) {
       })
     })
 
-    group.test('CouchDB Session invalid', {todo: true}, function (t) {
-      t.end()
+    group.test('CouchDB Session invalid', function (t) {
+      var options = _.defaultsDeep({
+        url: '/accounts/abc1234',
+        headers: {
+          authorization: 'Session InvalidKey'
+        }
+      }, routeOptions)
+      server.inject(options, function (response) {
+        t.is(response.statusCode, 401, 'returns 401 status')
+        t.is(response.result.errors.length, 1, 'returns one error')
+        t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
+        t.is(response.result.errors[0].detail, 'Session invalid', 'returns "Session invalid" message')
+        t.end()
+      })
     })
 
     group.test('Not an admin', {todo: true}, function (t) {


### PR DESCRIPTION
closes hoodiehq/camp#64