### PR TITLE
Add test for DELETE /accounts/{id} with invalid session

### DIFF
--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -212,7 +212,6 @@ function accountRoutes (server, options, next) {
           password: password,
           profile: profile
         }, {
-          sessionId: sessionId,
           include: request.query.include
         })
       })
@@ -260,8 +259,16 @@ function accountRoutes (server, options, next) {
     handler: function (request, reply) {
       var sessionId = toSessionId(request)
 
-      return accounts.remove(request.params.id, {
-        sessionId: sessionId
+      return admins.validateSession(sessionId)
+
+      .catch(function () {
+        throw errors.INVALID_SESSION
+      })
+
+      .then(function () {
+        return accounts.remove(request.params.id, {
+          sessionId: sessionId
+        })
       })
 
       .then(function (/* json */) {

--- a/tests/integration/routes/accounts/delete-accounts-test.js
+++ b/tests/integration/routes/accounts/delete-accounts-test.js
@@ -67,12 +67,12 @@ function mockCouchDbDeleteResponse () {
 
 test('DELETE /accounts/abc4567', function (group) {
   group.beforeEach(getServer)
+
   group.test('No Authorization header sent', function (t) {
-    this.server.inject({
-      method: 'DELETE',
-      url: '/accounts/abc4567',
-      headers: {}
-    }, function (response) {
+    var options = _.clone(routeOptions)
+    options.headers = {}
+
+    this.server.inject(options, function (response) {
       t.is(response.statusCode, 401, 'returns 401 status')
       t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
       t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
@@ -80,8 +80,17 @@ test('DELETE /accounts/abc4567', function (group) {
     })
   })
 
-  group.test('CouchDB Session invalid', {todo: true}, function (t) {
-    t.end()
+  group.test('Session invalid', function (t) {
+    var options = _.defaultsDeep({
+      headers: {
+        authorization: 'Session invalid'
+      }
+    }, routeOptions)
+
+    this.server.inject(options, function (response) {
+      t.is(response.statusCode, 401, '401 not found')
+      t.end()
+    })
   })
 
   group.test('Not an admin', {todo: true}, function (t) {


### PR DESCRIPTION
@gr2m, I just made test codes, but there still need to check. It didn't finish its test successfully.

closes hoodiehq/camp#74