### PR TITLE
ignore nodemailer updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "nodemailer"
+    ]
   }
 }


### PR DESCRIPTION
WE will stay on v2.x because of their new license:
https://nodemailer.com/about/license/