### PR TITLE
update @hoodie/account-server-api to version 3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@gar/hapi-json-api": "^2.0.1",
-    "@hoodie/account-server-api": "^3.6.3",
+    "@hoodie/account-server-api": "^3.8.0",
     "base64url": "^2.0.0",
     "boom": "^4.0.0",
     "couchdb-calculate-session-id": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@gar/hapi-json-api": "^2.0.1",
-    "@hoodie/account-server-api": "^3.8.0",
+    "@hoodie/account-server-api": "^3.8.2",
     "base64url": "^2.0.0",
     "boom": "^4.0.0",
     "couchdb-calculate-session-id": "^1.1.0",

--- a/tests/integration/routes/account/delete-account-test.js
+++ b/tests/integration/routes/account/delete-account-test.js
@@ -35,71 +35,66 @@ function mockCouchDbUserFound (docChange) {
     }, docChange))
 }
 
-getServer(function (error, server) {
-  if (error) {
-    return test('test setup', function (t) {
-      t.error(error)
+test('DELETE /session/account', function (group) {
+  group.beforeEach(getServer)
+
+  group.test('with valid session', function (t) {
+    // first mock is for validating session, 2nd is to get _rev for delete
+    var couch = mockCouchDbUserFound({_rev: '1-234'})
+      .put('/_users/org.couchdb.user%3Apat-doe', function (body) {
+        return Joi.object({
+          _id: Joi.any().only('org.couchdb.user:pat-doe').required(),
+          _rev: '1-234',
+          _deleted: true,
+          name: Joi.any().only('pat-doe').required(),
+          type: Joi.any().only('user').required(),
+          salt: Joi.string().required(),
+          derived_key: Joi.string().required(),
+          iterations: Joi.any().only(10).required(),
+          password_scheme: Joi.any().only('pbkdf2').required(),
+          roles: Joi.array().items(Joi.string())
+        }).validate(body).error === null
+      })
+      .query(true)
+      .reply(201, {
+        ok: true,
+        id: 'org.couchdb.user:pat-doe',
+        rev: '2-3456'
+      })
+
+    this.server.inject(routeOptions, function (response) {
+      t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
+
+      t.is(response.statusCode, 204, 'returns 204 status')
+      t.is(response.result, null, 'returns no body')
       t.end()
     })
-  }
-
-  test('DELETE /session/account', function (group) {
-    group.test('with valid session', function (t) {
-      // first mock is for validating session, 2nd is to get _rev for delete
-      mockCouchDbUserFound()
-      var couch = mockCouchDbUserFound({_rev: '1-234'})
-        .put('/_users/org.couchdb.user%3Apat-doe', function (body) {
-          return Joi.object({
-            _id: Joi.any().only('org.couchdb.user:pat-doe').required(),
-            _rev: '1-234',
-            _deleted: true,
-            name: Joi.any().only('pat-doe').required(),
-            type: Joi.any().only('user').required(),
-            salt: Joi.string().required(),
-            derived_key: Joi.string().required(),
-            iterations: Joi.any().only(10).required(),
-            password_scheme: Joi.any().only('pbkdf2').required(),
-            roles: Joi.array().items(Joi.string())
-          }).validate(body).error === null
-        })
-        .query(true)
-        .reply(201, {
-          ok: true,
-          id: 'org.couchdb.user:pat-doe',
-          rev: '2-3456'
-        })
-
-      server.inject(routeOptions, function (response) {
-        t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
-
-        t.is(response.statusCode, 204, 'returns 204 status')
-        t.is(response.result, null, 'returns no body')
-        t.end()
-      })
-    })
-
-    group.test('without valid session', function (t) {
-      var couch = couchdbGetUserMock
-        .reply(404, {error: 'Not Found'})
-
-      server.inject(routeOptions, function (response) {
-        t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
-        t.is(response.statusCode, 401, 'returns 401 status')
-        t.is(response.result.errors.length, 1, 'returns one error')
-        t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
-        t.is(response.result.errors[0].detail, 'Session invalid', 'returns "Session invalid" message')
-
-        t.end()
-      })
-    })
-
-    couchdbErrorTests(server, group, couchdbGetUserMock, routeOptions)
-
-    group.end()
   })
 
-  test('DELETE /session/account?include=profile', function (t) {
-    mockCouchDbUserFound()
+  group.test('without valid session', function (t) {
+    var couch = couchdbGetUserMock
+      .reply(404, {error: 'Not Found'})
+
+    this.server.inject(routeOptions, function (response) {
+      t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
+      t.is(response.statusCode, 401, 'returns 401 status')
+      t.is(response.result.errors.length, 1, 'returns one error')
+      t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
+      t.is(response.result.errors[0].detail, 'Session invalid', 'returns "Session invalid" message')
+
+      t.end()
+    })
+  })
+
+  couchdbErrorTests.call(this, group, couchdbGetUserMock, routeOptions)
+
+  group.end()
+})
+
+test('DELETE /session/account?include=profile', function (group) {
+  group.beforeEach(getServer)
+
+  group.test('with valid session', function (t) {
     var couch = mockCouchDbUserFound({_rev: '1-234'})
       .put('/_users/org.couchdb.user%3Apat-doe', function (body) {
         return Joi.object({
@@ -126,14 +121,20 @@ getServer(function (error, server) {
       url: '/session/account?include=profile'
     }, routeOptions)
 
-    server.inject(options, function (response) {
+    this.server.inject(options, function (response) {
       t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
       t.is(response.statusCode, 200, 'returns 200 status')
       t.end()
     })
   })
 
-  test('DELETE /session/account?include=foobar', function (t) {
+  group.end()
+})
+
+test('DELETE /session/account?include=foobar', function (t) {
+  getServer(function (error, server) {
+    t.error(error)
+
     var options = _.defaultsDeep({
       url: '/session/account?include=foobar'
     }, routeOptions)

--- a/tests/integration/routes/accounts/delete-accounts-test.js
+++ b/tests/integration/routes/accounts/delete-accounts-test.js
@@ -65,84 +65,76 @@ function mockCouchDbDeleteResponse () {
     .query(true)
 }
 
-getServer(function (error, server) {
-  if (error) {
-    return test('test setup', function (t) {
-      t.error(error)
+test('DELETE /accounts/abc4567', function (group) {
+  group.beforeEach(getServer)
+  group.test('No Authorization header sent', function (t) {
+    this.server.inject({
+      method: 'DELETE',
+      url: '/accounts/abc4567',
+      headers: {}
+    }, function (response) {
+      t.is(response.statusCode, 401, 'returns 401 status')
+      t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
+      t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
       t.end()
     })
-  }
-
-  test('DELETE /accounts/abc4567', function (group) {
-    group.test('No Authorization header sent', function (t) {
-      server.inject({
-        method: 'DELETE',
-        url: '/accounts/abc4567',
-        headers: {}
-      }, function (response) {
-        t.is(response.statusCode, 401, 'returns 401 status')
-        t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
-        t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
-        t.end()
-      })
-    })
-
-    group.test('CouchDB Session invalid', {todo: true}, function (t) {
-      t.end()
-    })
-
-    group.test('Not an admin', {todo: true}, function (t) {
-      t.end()
-    })
-
-    group.test('account not found', function (t) {
-      var couchdb = nock('http://localhost:5984')
-        .get('/_users/_design/byId/_view/byId')
-        .query({
-          key: '"abc4567"',
-          include_docs: true
-        })
-        .reply(200, {total_rows: 1, offset: 0, rows: []})
-
-      server.inject(routeOptions, function (response) {
-        t.is(couchdb.pendingMocks()[0], undefined, 'all mocks satisfied')
-        t.is(response.statusCode, 404, 'returns 404 status')
-        t.end()
-      })
-    })
-
-    group.test('account exists', function (t) {
-      var couchdb = mockCouchDbDeleteResponse()
-        .reply(201, {
-          ok: true,
-          id: 'org.couchdb.user:pat-doe',
-          rev: '2-3456'
-        })
-
-      server.inject(routeOptions, function (response) {
-        t.is(couchdb.pendingMocks()[0], undefined, 'all mocks satisfied')
-        t.is(response.statusCode, 204, 'returns 204 status')
-        t.is(response.result, null, 'returns no content')
-        t.end()
-      })
-    })
-
-    group.test('with ?include=profile', {todo: true}, function (t) {
-      t.end()
-    })
-
-    group.test('with ?include=foobar', {todo: true}, function (t) {
-      var options = _.defaultsDeep({
-        url: '/accounts/123?include=foobar'
-      }, routeOptions)
-
-      server.inject(options, function (response) {
-        t.is(response.statusCode, 400, 'returns 400 status')
-        t.deepEqual(response.result.errors[0].detail, 'Allowed value for ?include is \'profile\'', 'returns error message')
-        t.end()
-      })
-    })
-
-    group.end()
   })
+
+  group.test('CouchDB Session invalid', {todo: true}, function (t) {
+    t.end()
+  })
+
+  group.test('Not an admin', {todo: true}, function (t) {
+    t.end()
+  })
+
+  group.test('account not found', function (t) {
+    var couchdb = nock('http://localhost:5984')
+      .get('/_users/_design/byId/_view/byId')
+      .query({
+        key: '"abc4567"',
+        include_docs: true
+      })
+      .reply(200, {total_rows: 1, offset: 0, rows: []})
+
+    this.server.inject(routeOptions, function (response) {
+      t.is(couchdb.pendingMocks()[0], undefined, 'all mocks satisfied')
+      t.is(response.statusCode, 404, 'returns 404 status')
+      t.end()
+    })
+  })
+
+  group.test('account exists', function (t) {
+    var couchdb = mockCouchDbDeleteResponse()
+      .reply(201, {
+        ok: true,
+        id: 'org.couchdb.user:pat-doe',
+        rev: '2-3456'
+      })
+
+    this.server.inject(routeOptions, function (response) {
+      t.is(couchdb.pendingMocks()[0], undefined, 'all mocks satisfied')
+      t.is(response.statusCode, 204, 'returns 204 status')
+      t.is(response.result, null, 'returns no content')
+      t.end()
+    })
+  })
+
+  group.test('with ?include=profile', {todo: true}, function (t) {
+    t.end()
+  })
+
+  group.test('with ?include=foobar', {todo: true}, function (t) {
+    var options = _.defaultsDeep({
+      url: '/accounts/123?include=foobar'
+    }, routeOptions)
+
+    this.server.inject(options, function (response) {
+      t.is(response.statusCode, 400, 'returns 400 status')
+      t.deepEqual(response.result.errors[0].detail, 'Allowed value for ?include is \'profile\'', 'returns error message')
+      t.end()
+    })
+  })
+
+  group.end()
 })

--- a/tests/integration/routes/accounts/patch-accounts-test.js
+++ b/tests/integration/routes/accounts/patch-accounts-test.js
@@ -67,150 +67,143 @@ function mockCouchDbUpdateAccountResponse () {
     .query(true)
 }
 
-getServer(function (error, server) {
-  if (error) {
-    return test('test setup', function (t) {
-      t.error(error)
+test('PATCH /accounts/abc4567', function (group) {
+  group.beforeEach(getServer)
+
+  group.test('No Authorization header sent', function (t) {
+    this.server.inject({
+      method: 'PATCH',
+      url: '/accounts/abc4567',
+      headers: {}
+    }, function (response) {
+      t.is(response.statusCode, 401, 'returns 401 status')
+      t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
+      t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
       t.end()
     })
-  }
+  })
 
-  test('PATCH /accounts/abc4567', function (group) {
-    group.test('No Authorization header sent', function (t) {
-      server.inject({
-        method: 'PATCH',
-        url: '/accounts/abc4567',
-        headers: {}
-      }, function (response) {
-        t.is(response.statusCode, 401, 'returns 401 status')
-        t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
-        t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
-        t.end()
-      })
+  group.test('CouchDB Session invalid', function (t) {
+    var options = _.defaultsDeep({
+      headers: {
+        authorization: 'Session InvalidKey'
+      }
+    }, routeOptions)
+    this.server.inject(options, function (response) {
+      t.is(response.statusCode, 401, 'returns 401 status')
+      t.is(response.result.errors.length, 1, 'returns one error')
+      t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
+      t.is(response.result.errors[0].detail, 'Session invalid', 'returns "Session invalid" message')
+      t.end()
     })
+  })
 
-    group.test('CouchDB Session invalid', function (t) {
-      var options = _.defaultsDeep({
-        headers: {
-          authorization: 'Session InvalidKey'
-        }
-      }, routeOptions)
-      server.inject(options, function (response) {
-        t.is(response.statusCode, 401, 'returns 401 status')
-        t.is(response.result.errors.length, 1, 'returns one error')
-        t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
-        t.is(response.result.errors[0].detail, 'Session invalid', 'returns "Session invalid" message')
-        t.end()
-      })
+  group.test('Not an admin', function (t) {
+    var options = _.defaultsDeep({
+      headers: {
+        // Session ID based on 'pat-doe', 'salt123', 'secret', 1209600
+        authorization: 'Session cGF0LWRvZTpCQkZFMzg4MDqp7ppCNngda1JMi7XcyhtaUxf2nA'
+      }
+    }, routeOptions)
+
+    this.server.inject(options, function (response) {
+      t.is(response.statusCode, 401, 'returns 401 status')
+      t.is(response.result.errors.length, 1, 'returns one error')
+      t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
+      t.is(response.result.errors[0].detail, 'Session invalid', 'returns Invalid session message')
+      t.end()
     })
+  })
 
-    group.test('Not an admin', function (t) {
-      var options = _.defaultsDeep({
-        headers: {
-          // Session ID based on 'pat-doe', 'salt123', 'secret', 1209600
-          authorization: 'Session cGF0LWRvZTpCQkZFMzg4MDqp7ppCNngda1JMi7XcyhtaUxf2nA'
-        }
-      }, routeOptions)
-
-      server.inject(options, function (response) {
-        t.is(response.statusCode, 401, 'returns 401 status')
-        t.is(response.result.errors.length, 1, 'returns one error')
-        t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
-        t.is(response.result.errors[0].detail, 'Session invalid', 'returns Invalid session message')
-        t.end()
-      })
-    })
-
-    group.test('Not found', function (t) {
-      var couchdb = nock('http://localhost:5984')
-          .get('/_users/_design/byId/_view/byId')
-          .query({
-            key: '"xyz1234"',
-            include_docs: true
-          })
-          .reply(200, {
-            total_rows: 1,
-            offset: 0,
-            rows: []
-          })
-
-      server.inject({
-        method: 'PATCH',
-        url: '/accounts/xyz1234',
-        headers: routeOptions.headers,
-        payload: {
-          data: {
-            type: 'account',
-            id: 'xyz1234',
-            attributes: {
-              password: 'newsecret'
-            }
-          }
-        }
-      }, function (response) {
-        t.is(couchdb.pendingMocks()[0], undefined, 'all mocks satisfied')
-        t.is(response.statusCode, 404, 'returns 404 status')
-        t.is(response.result.errors.length, 1, 'returns one error')
-        t.is(response.result.errors[0].title, 'Not Found', 'returns "Not Found" error')
-        t.is(response.result.errors[0].detail, 'Account Id Not Found', 'returns "Account Id Not Found" message')
-        t.end()
-      })
-    })
-
-    group.test('data.type & data.id don’t match existing document', function (t) {
-      server.inject(Object.assign({}, routeOptions, {
-        payload: {
-          data: {
-            type: 'not-account',
-            id: 'not-abc456'
-          }
-        }
-      }), function (response) {
-        t.is(response.statusCode, 409, 'returns 409 status')
-        t.end()
-      })
-    })
-
-    group.test('changing password', function (t) {
-      var couchdb = mockCouchDbUpdateAccountResponse()
-        .reply(201, {
-          ok: true,
-          id: 'org.couchdb.user:pat-doe',
-          rev: '2-3456'
+  group.test('Not found', function (t) {
+    var couchdb = nock('http://localhost:5984')
+        .get('/_users/_design/byId/_view/byId')
+        .query({
+          key: '"xyz1234"',
+          include_docs: true
+        })
+        .reply(200, {
+          total_rows: 1,
+          offset: 0,
+          rows: []
         })
 
-      server.inject(routeOptions, function (response) {
-        t.is(couchdb.pendingMocks()[0], undefined, 'all mocks satisfied')
-        t.is(response.statusCode, 204, 'returns 204 status')
-        t.is(response.result, null, 'returns no content')
-        t.end()
-      })
-    })
-
-    group.test('changing username', {todo: true}, function (t) {
+    this.server.inject({
+      method: 'PATCH',
+      url: '/accounts/xyz1234',
+      headers: routeOptions.headers,
+      payload: {
+        data: {
+          type: 'account',
+          id: 'xyz1234',
+          attributes: {
+            password: 'newsecret'
+          }
+        }
+      }
+    }, function (response) {
+      t.is(couchdb.pendingMocks()[0], undefined, 'all mocks satisfied')
+      t.is(response.statusCode, 404, 'returns 404 status')
+      t.is(response.result.errors.length, 1, 'returns one error')
+      t.is(response.result.errors[0].title, 'Not Found', 'returns "Not Found" error')
+      t.is(response.result.errors[0].detail, 'Account Id Not Found', 'returns "Account Id Not Found" message')
       t.end()
     })
-
-    group.test('with ?include=profile', {todo: true}, function (t) {
-      t.end()
-    })
-
-    group.test('with ?include=foobar', function (t) {
-      var options = _.defaultsDeep({
-        url: '/accounts/abcd4567?include=foobar'
-      }, routeOptions)
-
-      server.inject(options, function (response) {
-        t.is(response.statusCode, 400, 'returns 400 status')
-        t.deepEqual(response.result.errors[0].detail, 'Allowed value for ?include is \'profile\'', 'returns error message')
-        t.end()
-      })
-    })
-
-    // TOOD: test server error handling
-    // couchdbErrorTests(server, group, mockCouchDbUpdateAccountResponse(), routeOptions)
-    invalidTypeErrors(server, group, routeOptions, 'account')
-
-    group.end()
   })
+
+  group.test('data.type & data.id don’t match existing document', function (t) {
+    this.server.inject(Object.assign({}, routeOptions, {
+      payload: {
+        data: {
+          type: 'not-account',
+          id: 'not-abc456'
+        }
+      }
+    }), function (response) {
+      t.is(response.statusCode, 409, 'returns 409 status')
+      t.end()
+    })
+  })
+
+  group.test('changing password', function (t) {
+    var couchdb = mockCouchDbUpdateAccountResponse()
+      .reply(201, {
+        ok: true,
+        id: 'org.couchdb.user:pat-doe',
+        rev: '2-3456'
+      })
+
+    this.server.inject(routeOptions, function (response) {
+      t.is(couchdb.pendingMocks()[0], undefined, 'all mocks satisfied')
+      t.is(response.statusCode, 204, 'returns 204 status')
+      t.is(response.result, null, 'returns no content')
+      t.end()
+    })
+  })
+
+  group.test('changing username', {todo: true}, function (t) {
+    t.end()
+  })
+
+  group.test('with ?include=profile', {todo: true}, function (t) {
+    t.end()
+  })
+
+  group.test('with ?include=foobar', function (t) {
+    var options = _.defaultsDeep({
+      url: '/accounts/abcd4567?include=foobar'
+    }, routeOptions)
+
+    this.server.inject(options, function (response) {
+      t.is(response.statusCode, 400, 'returns 400 status')
+      t.deepEqual(response.result.errors[0].detail, 'Allowed value for ?include is \'profile\'', 'returns error message')
+      t.end()
+    })
+  })
+
+  // TOOD: test server error handling
+  // couchdbErrorTests(server, group, mockCouchDbUpdateAccountResponse(), routeOptions)
+  invalidTypeErrors(group, routeOptions, 'account')
+
+  group.end()
 })

--- a/tests/integration/routes/no-cookie-header-test.js
+++ b/tests/integration/routes/no-cookie-header-test.js
@@ -19,40 +19,27 @@ var routePOSTOptions = {
 }
 
 test('Recieve no cookie on GET Request', function (group) {
-  getServer({}, function (error, server) {
-    if (error) {
-      group.error(error)
-      group.end()
-      return
-    }
+  group.beforeEach(getServer)
 
-    group.test('GET no cookie', function (t) {
-      server.inject(routeOptions, function (response) {
-        t.is(response.raw.req.headers.cookie, undefined, 'Header Cookie on GET Request should be null')
-        t.end()
-      })
+  group.test('GET no cookie', function (t) {
+    this.server.inject(routeOptions, function (response) {
+      t.is(response.raw.req.headers.cookie, undefined, 'Header Cookie on GET Request should be null')
+      t.end()
     })
-
-    group.end()
   })
+
+  group.end()
 })
 
 test('Recieve no cookie on POST Request', function (group) {
-  getServer({}, function (error, server) {
-    if (error) {
-      return test('test setup', function (t) {
-        t.error(error)
-        t.end()
-      })
-    }
+  group.beforeEach(getServer)
 
-    group.test('POST no cookie', function (t) {
-      server.inject(routePOSTOptions, function (response) {
-        t.is(response.raw.req.headers.cookie, undefined, 'Header Cookie on GET Request should be null')
-        t.end()
-      })
+  group.test('POST no cookie', function (t) {
+    this.server.inject(routePOSTOptions, function (response) {
+      t.is(response.raw.req.headers.cookie, undefined, 'Header Cookie on GET Request should be null')
+      t.end()
     })
-
-    group.end()
   })
+
+  group.end()
 })

--- a/tests/integration/routes/profile/patch-profile-test.js
+++ b/tests/integration/routes/profile/patch-profile-test.js
@@ -43,109 +43,105 @@ function mockUserFound (docChange) {
     }, docChange))
 }
 
-getServer(function (error, server) {
-  if (error) {
-    return test('test setup', function (t) {
-      t.error(error)
+test('PATCH /session/account/profile', function (group) {
+  group.beforeEach(getServer)
+
+  // For now all tests within here are skipped anyway
+  couchdbErrorTests(group, mockCouchDbGetUserDoc, routeOptions)
+
+  group.test('Session does exist', function (t) {
+    // Mock the update
+    nock('http://localhost:5984')
+      .put('/_users/org.couchdb.user%3Apat-doe')
+      .reply(201, {
+        ok: true,
+        id: 'org.couchdb.user:pat-doe',
+        rev: '2-3456'
+      })
+
+    var couch = mockUserFound({
+      profile: {
+        fullName: 'Pat Doe',
+        email: 'pat@example.com'
+      }
+    })
+    this.server.inject(routeOptions, function (response) {
+      t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
+      // The PATCH updated the email
+      t.is(response.statusCode, 204, 'returns 204 status')
+      t.is(response.result, null, 'returns no body')
       t.end()
     })
-  }
-
-  test('PATCH /session/account/profile', function (group) {
-    // For now all tests within here are skipped anyway
-    couchdbErrorTests(server, group, mockCouchDbGetUserDoc, routeOptions)
-
-    group.test('Session does exist', function (t) {
-      // Mock the update
-      nock('http://localhost:5984')
-        .put('/_users/org.couchdb.user%3Apat-doe')
-        .reply(201, {
-          ok: true,
-          id: 'org.couchdb.user:pat-doe',
-          rev: '2-3456'
-        })
-      // Need to mock 2 times the found, one for the session, one before the update
-      mockUserFound()
-      var couch = mockUserFound({
-        profile: {
-          fullName: 'Pat Doe',
-          email: 'pat@example.com'
-        }
-      })
-      server.inject(routeOptions, function (response) {
-        t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
-        // The PATCH updated the email
-        t.is(response.statusCode, 204, 'returns 204 status')
-        t.is(response.result, null, 'returns no body')
-        t.end()
-      })
-    })
-
-    group.test('Session does not exist', function (t) {
-      var couch = mockCouchDbGetUserDoc
-            .reply(404, {error: 'not_found', reason: 'missing'})
-
-      server.inject(routeOptions, function (response) {
-        t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
-
-        t.is(response.statusCode, 401, 'returns 401 status')
-        t.is(response.result.errors.length, 1, 'returns one error')
-        t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
-        t.is(response.result.errors[0].detail, 'Session invalid', 'returns "Session invalid" error')
-        t.end()
-      })
-    })
-
-    group.test('User Is admin', function (t) {
-      var requestOptions = _.defaultsDeep({
-        headers: {
-          // calculateSessionId('admin', '1081b31861bd1e91611341da16c11c16a12c13718d1f712e', 'secret', 1209600)
-          authorization: 'Session YWRtaW46MTI3NTAwOh08V1EljPqAPAnv8mtxWNF87zdW'
-        }
-      }, routeOptions)
-
-      server.inject(requestOptions, function (response) {
-        delete response.result.meta
-        t.is(response.statusCode, 404, 'returns 404 status')
-        t.is(response.result.errors.length, 1, 'returns one error')
-        t.is(response.result.errors[0].title, 'Not Found', 'returns "Not Found" error')
-        t.is(response.result.errors[0].detail, 'Admins have no profiles', 'returns "Admins have no profiles" error')
-        t.end()
-      })
-    })
-
-    // test prepared for https://github.com/hoodiehq/hoodie-account-server/issues/104
-    group.test('data.id is != account.id belonging to session', function (t) {
-      var couch = mockUserFound()
-      var options = _.defaultsDeep({
-        payload: {
-          data: {
-            id: 'foobar-profile'
-          }
-        }
-      }, routeOptions)
-
-      server.inject(options, function (response) {
-        t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
-
-        t.is(response.statusCode, 409, 'returns 409 status')
-        t.is(response.result.errors.length, 1, 'returns one error')
-        t.is(response.result.errors[0].title, 'Conflict', 'returns "Conflict" error')
-        t.is(response.result.errors[0].detail, 'data.id must be \'userid123-profile\'', 'returns "data.id must be \'userid123-profile\'" message')
-
-        t.end()
-      })
-    })
-
-    group.end()
   })
 
-  test('PATCH /session/account/profile?include=foobar', function (t) {
+  group.test('Session does not exist', function (t) {
+    var couch = mockCouchDbGetUserDoc
+          .reply(404, {error: 'not_found', reason: 'missing'})
+
+    this.server.inject(routeOptions, function (response) {
+      t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
+
+      t.is(response.statusCode, 401, 'returns 401 status')
+      t.is(response.result.errors.length, 1, 'returns one error')
+      t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
+      t.is(response.result.errors[0].detail, 'Session invalid', 'returns "Session invalid" error')
+      t.end()
+    })
+  })
+
+  group.test('User Is admin', function (t) {
+    var requestOptions = _.defaultsDeep({
+      headers: {
+        // calculateSessionId('admin', '1081b31861bd1e91611341da16c11c16a12c13718d1f712e', 'secret', 1209600)
+        authorization: 'Session YWRtaW46MTI3NTAwOh08V1EljPqAPAnv8mtxWNF87zdW'
+      }
+    }, routeOptions)
+
+    this.server.inject(requestOptions, function (response) {
+      delete response.result.meta
+      t.is(response.statusCode, 404, 'returns 404 status')
+      t.is(response.result.errors.length, 1, 'returns one error')
+      t.is(response.result.errors[0].title, 'Not Found', 'returns "Not Found" error')
+      t.is(response.result.errors[0].detail, 'Admins have no profiles', 'returns "Admins have no profiles" error')
+      t.end()
+    })
+  })
+
+  // test prepared for https://github.com/hoodiehq/hoodie-account-server/issues/104
+  group.test('data.id is != account.id belonging to session', function (t) {
+    var couch = mockUserFound()
+    var options = _.defaultsDeep({
+      payload: {
+        data: {
+          id: 'foobar-profile'
+        }
+      }
+    }, routeOptions)
+
+    this.server.inject(options, function (response) {
+      t.is(couch.pendingMocks()[0], undefined, 'all mocks satisfied')
+
+      t.is(response.statusCode, 409, 'returns 409 status')
+      t.is(response.result.errors.length, 1, 'returns one error')
+      t.is(response.result.errors[0].title, 'Conflict', 'returns "Conflict" error')
+      t.is(response.result.errors[0].detail, 'data.id must be \'userid123-profile\'', 'returns "data.id must be \'userid123-profile\'" message')
+
+      t.end()
+    })
+  })
+
+  group.end()
+})
+
+test('PATCH /session/account/profile?include=foobar', function (t) {
+  getServer(function (error, server) {
+    t.error(error)
+
     var options = _.defaultsDeep({
       url: '/session/account/profile?include=foobar'
     }, routeOptions)
 
-    server.inject(options, function (response) {
+    this.server.inject(options, function (response) {
       t.is(response.statusCode, 400, 'returns 400 status')
       t.deepEqual(response.result.errors[0].detail, '?include not allowed', 'returns error message')
       t.end()

--- a/tests/integration/routes/session/delete-session-test.js
+++ b/tests/integration/routes/session/delete-session-test.js
@@ -22,31 +22,67 @@ var couchdbGetUserMock = nock('http://localhost:5984')
   .query(true)
 
 test('DELETE /session', function (group) {
-  getServer(function (error, server) {
-    if (error) {
-      group.error(error)
-      group.end()
-      return
+  group.beforeEach(getServer)
+
+  couchdbErrorTests(group, couchdbGetUserMock, routeOptions)
+
+  group.test('No Authorization header sent', function (t) {
+    var requestOptions = cloneDeep(routeOptions)
+    delete requestOptions.headers.authorization
+
+    this.server.inject(requestOptions, function (response) {
+      t.is(response.statusCode, 401, 'returns 401 status')
+      t.is(response.result.errors.length, 1, 'returns one error')
+      t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
+      t.is(response.result.errors[0].detail, 'Authorization header missing', 'returns "Authorization header missing" error')
+      t.end()
+    })
+  })
+
+  group.test('User not found', function (t) {
+    var couchdb = couchdbGetUserMock.reply(401, {error: 'Unauthorized'})
+
+    this.server.inject(routeOptions, function (response) {
+      t.is(couchdb.pendingMocks()[0], undefined, 'CouchDB received request')
+      t.is(response.statusCode, 401, 'returns 401 status')
+      t.is(response.result.errors.length, 1, 'returns one error')
+      t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
+      t.is(response.result.errors[0].detail, 'Session invalid', 'returns "Session invalid" message')
+      t.end()
+    })
+  })
+
+  group.test('User found', function (subGroup) {
+    function couchdbUserFoundMock () {
+      return couchdbGetUserMock.reply(200, {
+        name: 'pat-doe',
+        roles: [
+          'id:userid123', 'mycustomrole'
+        ],
+        salt: 'salt123'
+      })
     }
-    couchdbErrorTests(server, group, couchdbGetUserMock, routeOptions)
+    subGroup.test('Session valid', function (t) {
+      var couchdb = couchdbUserFoundMock()
 
-    group.test('No Authorization header sent', function (t) {
-      var requestOptions = cloneDeep(routeOptions)
-      delete requestOptions.headers.authorization
-
-      server.inject(requestOptions, function (response) {
-        t.is(response.statusCode, 401, 'returns 401 status')
-        t.is(response.result.errors.length, 1, 'returns one error')
-        t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
-        t.is(response.result.errors[0].detail, 'Authorization header missing', 'returns "Authorization header missing" error')
+      this.server.inject(routeOptions, function (response) {
+        t.is(couchdb.pendingMocks()[0], undefined, 'CouchDB received request')
+        t.is(response.statusCode, 204, 'returns 204 status')
         t.end()
       })
     })
 
-    group.test('User not found', function (t) {
-      var couchdb = couchdbGetUserMock.reply(401, {error: 'Unauthorized'})
+    subGroup.test('Session invalid', function (t) {
+      var couchdb = couchdbUserFoundMock()
 
-      server.inject(routeOptions, function (response) {
+      var requestOptions = defaultsDeep({
+        headers: {
+          // Token calculated with invalid salt (salt456)
+          authorization: 'Session cGF0LWRvZToxMjc1MDA6YMtzOJDSC7iTA4cB2kjfjqbfk1Y'
+        }
+      }, routeOptions)
+
+      this.server.inject(requestOptions, function (response) {
         t.is(couchdb.pendingMocks()[0], undefined, 'CouchDB received request')
         t.is(response.statusCode, 401, 'returns 401 status')
         t.is(response.result.errors.length, 1, 'returns one error')
@@ -56,93 +92,47 @@ test('DELETE /session', function (group) {
       })
     })
 
-    group.test('User found', function (subGroup) {
-      function couchdbUserFoundMock () {
-        return couchdbGetUserMock.reply(200, {
-          name: 'pat-doe',
-          roles: [
-            'id:userid123', 'mycustomrole'
-          ],
-          salt: 'salt123'
-        })
-      }
-      subGroup.test('Session valid', function (t) {
-        var couchdb = couchdbUserFoundMock()
-
-        server.inject(routeOptions, function (response) {
-          t.is(couchdb.pendingMocks()[0], undefined, 'CouchDB received request')
-          t.is(response.statusCode, 204, 'returns 204 status')
-          t.end()
-        })
-      })
-
-      subGroup.test('Session invalid', function (t) {
-        var couchdb = couchdbUserFoundMock()
-
-        var requestOptions = defaultsDeep({
-          headers: {
-            // Token calculated with invalid salt (salt456)
-            authorization: 'Session cGF0LWRvZToxMjc1MDA6YMtzOJDSC7iTA4cB2kjfjqbfk1Y'
-          }
-        }, routeOptions)
-
-        server.inject(requestOptions, function (response) {
-          t.is(couchdb.pendingMocks()[0], undefined, 'CouchDB received request')
-          t.is(response.statusCode, 401, 'returns 401 status')
-          t.is(response.result.errors.length, 1, 'returns one error')
-          t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
-          t.is(response.result.errors[0].detail, 'Session invalid', 'returns "Session invalid" message')
-          t.end()
-        })
-      })
-
-      subGroup.end()
-    })
-
-    group.end()
+    subGroup.end()
   })
+
+  group.end()
 })
 
 test('DELETE /session?include=account', function (group) {
-  getServer(function (error, server) {
-    if (error) {
-      group.error(error)
-      group.end()
-      return
-    }
-    var options = defaultsDeep({
-      url: '/session?include=account'
-    }, routeOptions)
+  var options = defaultsDeep({
+    url: '/session?include=account'
+  }, routeOptions)
 
-    group.test('User found', function (subGroup) {
-      function couchdbUserFoundMock () {
-        return couchdbGetUserMock.reply(200, {
-          name: 'pat-doe',
-          roles: [
-            'id:userid123', 'mycustomrole'
-          ],
-          salt: 'salt123'
-        })
-      }
-      subGroup.test('Session valid', function (t) {
-        var couchdb = couchdbUserFoundMock()
+  group.beforeEach(getServer)
 
-        var sessionResponse = require('../../fixtures/session-response.json')
-
-        server.inject(options, function (response) {
-          t.is(couchdb.pendingMocks()[0], undefined, 'CouchDB received request')
-          delete response.result.meta
-          t.is(response.statusCode, 200, 'returns 200 status')
-          t.deepEqual(response.result, sessionResponse, 'returns the right content')
-          t.end()
-        })
+  group.test('User found', function (subGroup) {
+    function couchdbUserFoundMock () {
+      return couchdbGetUserMock.reply(200, {
+        name: 'pat-doe',
+        roles: [
+          'id:userid123', 'mycustomrole'
+        ],
+        salt: 'salt123'
       })
+    }
+    subGroup.test('Session valid', function (t) {
+      var couchdb = couchdbUserFoundMock()
 
-      subGroup.end()
+      var sessionResponse = require('../../fixtures/session-response.json')
+
+      this.server.inject(options, function (response) {
+        t.is(couchdb.pendingMocks()[0], undefined, 'CouchDB received request')
+        delete response.result.meta
+        t.is(response.statusCode, 200, 'returns 200 status')
+        t.deepEqual(response.result, sessionResponse, 'returns the right content')
+        t.end()
+      })
     })
 
-    group.end()
+    subGroup.end()
   })
+
+  group.end()
 })
 
 test('DELETE /session?include=account.profile', function (group) {
@@ -150,64 +140,54 @@ test('DELETE /session?include=account.profile', function (group) {
     url: '/session?include=account.profile'
   }, routeOptions)
 
-  getServer(function (error, server) {
-    if (error) {
-      group.error(error)
-      group.end()
-      return
+  group.beforeEach(getServer)
+
+  group.test('User found', function (subGroup) {
+    function couchdbUserFoundMock () {
+      return couchdbGetUserMock.reply(200, {
+        name: 'pat-doe',
+        roles: [
+          'id:userid123', 'mycustomrole'
+        ],
+        salt: 'salt123',
+        profile: {
+          fullName: 'pat Doe',
+          email: 'pat@example.com'
+        }
+      })
     }
 
-    group.test('User found', function (subGroup) {
-      function couchdbUserFoundMock () {
-        return couchdbGetUserMock.reply(200, {
-          name: 'pat-doe',
-          roles: [
-            'id:userid123', 'mycustomrole'
-          ],
-          salt: 'salt123',
-          profile: {
-            fullName: 'pat Doe',
-            email: 'pat@example.com'
-          }
-        })
-      }
+    subGroup.test('Session valid', function (t) {
+      var couchdb = couchdbUserFoundMock()
 
-      subGroup.test('Session valid', function (t) {
-        var couchdb = couchdbUserFoundMock()
+      var sessionWithProfileResponse = require('../../fixtures/session-with-profile-response.json')
 
-        var sessionWithProfileResponse = require('../../fixtures/session-with-profile-response.json')
-
-        server.inject(options, function (response) {
-          t.is(couchdb.pendingMocks()[0], undefined, 'CouchDB received request')
-          delete response.result.meta
-          t.is(response.statusCode, 200, 'returns 200 status')
-          t.deepEqual(response.result, sessionWithProfileResponse, 'returns the right content')
-          t.end()
-        })
+      this.server.inject(options, function (response) {
+        t.is(couchdb.pendingMocks()[0], undefined, 'CouchDB received request')
+        delete response.result.meta
+        t.is(response.statusCode, 200, 'returns 200 status')
+        t.deepEqual(response.result, sessionWithProfileResponse, 'returns the right content')
+        t.end()
       })
-
-      subGroup.end()
     })
 
-    group.end()
+    subGroup.end()
   })
+
+  group.end()
 })
 
 test('DELETE /session?include=foobar', function (t) {
-  getServer(function (error, server) {
-    if (error) {
-      t.error(error)
-      t.end()
-      return
-    }
+  t.plan(2)
 
-    t.plan(1)
+  getServer(function (error, server) {
+    t.error(error)
 
     var options = defaultsDeep({
       url: '/session?include=foobar'
     }, routeOptions)
 
-    server.inject(options, function (response) {
+    this.server.inject(options, function (response) {
       t.is(response.statusCode, 400, 'returns 400 status')
     })
   })

--- a/tests/integration/routes/session/get-session-test.js
+++ b/tests/integration/routes/session/get-session-test.js
@@ -21,164 +21,149 @@ var mockCouchDbGetUser = nock('http://localhost:5984')
   .query(true)
 
 test('GET /session', function (group) {
-  getServer(function (error, server) {
-    if (error) {
-      group.error(error)
-      group.end()
-      return
-    }
-    couchdbErrorTests(server, group, mockCouchDbGetUser, routeOptions)
+  group.beforeEach(getServer)
 
-    group.test('No Authorization header sent', function (t) {
-      server.inject({
-        method: 'GET',
-        url: '/session',
-        headers: {}
-      }, function (response) {
-        t.is(response.statusCode, 401, 'returns 401 status')
-        t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
-        t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
+  couchdbErrorTests(group, mockCouchDbGetUser, routeOptions)
 
-        // TODO:
-        // - response.result.error should be response.result.errors[0].title
-        // - response.result.message should be  response.result.errors[0].msesage
-        // - and we should check for response.result.errors.length === 1
-        // ^ these are currently blocked by https://github.com/wraithgar/hapi-json-api/issues/20
-        t.end()
-      })
+  group.test('No Authorization header sent', function (t) {
+    this.server.inject({
+      method: 'GET',
+      url: '/session',
+      headers: {}
+    }, function (response) {
+      t.is(response.statusCode, 401, 'returns 401 status')
+      t.is(response.result.error, 'Unauthorized', 'returns "Unauthorized" error')
+      t.is(response.result.message, 'Authorization header missing', 'returns "Authorization header missing" error')
+
+      // TODO:
+      // - response.result.error should be response.result.errors[0].title
+      // - response.result.message should be  response.result.errors[0].msesage
+      // - and we should check for response.result.errors.length === 1
+      // ^ these are currently blocked by https://github.com/wraithgar/hapi-json-api/issues/20
+      t.end()
     })
-
-    group.test('User not found', function (t) {
-      var couchdb = mockCouchDbGetUser.reply(404, {error: 'Not Found'})
-
-      server.inject(routeOptions, function (response) {
-        t.is(couchdb.pendingMocks()[0], undefined, 'CouchDB received request')
-        t.is(response.statusCode, 401, 'returns 401 status')
-        t.is(response.result.errors.length, 1, 'returns one error')
-        t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Session invalid" error')
-        t.end()
-      })
-    })
-
-    group.test('User found', function (subGroup) {
-      subGroup.test('Session valid', function (t) {
-        mockCouchDbGetUser.reply(200, {
-          name: 'pat-doe',
-          roles: [
-            'id:userid123', 'mycustomrole'
-          ],
-          salt: 'salt123'
-        })
-
-        var sessionResponse = require('../../fixtures/session-response.json')
-
-        server.inject(routeOptions, function (response) {
-          delete response.result.meta
-          t.is(response.statusCode, 200, 'returns 200 status')
-          t.deepEqual(response.result, sessionResponse, 'returns the right content')
-          t.end()
-        })
-      })
-
-      subGroup.test('Session invalid', function (t) {
-        mockCouchDbGetUser.reply(200, {
-          name: 'pat-doe',
-          roles: [
-            'id:userid123', 'mycustomrole'
-          ],
-          salt: 'salt123'
-        })
-
-        var requestOptions = defaultsDeep({
-          headers: {
-            // Token calculated with invalid salt (salt456)
-            authorization: 'Session cGF0LWRvZToxMjc1MDA6YMtzOJDSC7iTA4cB2kjfjqbfk1Y'
-          }
-        }, routeOptions)
-
-        server.inject(requestOptions, function (response) {
-          t.is(response.statusCode, 401, 'returns 401 status')
-          t.is(response.result.errors.length, 1, 'returns one error')
-          t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
-          t.is(response.result.errors[0].detail, 'Session invalid', 'returns "Session invalid" message')
-          t.end()
-        })
-      })
-
-      subGroup.end()
-    })
-
-    group.test('User is admin', function (t) {
-      var requestOptions = defaultsDeep({
-        headers: {
-          // calculateSessionId('admin', '1081b31861bd1e91611341da16c11c16a12c13718d1f712e', 'secret', 1209600)
-          authorization: 'Session YWRtaW46MTI3NTAwOh08V1EljPqAPAnv8mtxWNF87zdW'
-        }
-      }, routeOptions)
-
-      var sessionAdminResponse = require('../../fixtures/session-admin-response.json')
-
-      server.inject(requestOptions, function (response) {
-        delete response.result.meta
-        t.is(response.statusCode, 200, 'returns 200 status')
-        t.deepEqual(response.result, sessionAdminResponse, 'returns the right content')
-        t.end()
-      })
-    })
-
-    group.end()
   })
-})
 
-test('GET /session?include=account.profile', function (group) {
-  getServer(function (error, server) {
-    if (error) {
-      group.error(error)
-      group.end()
-      return
-    }
+  group.test('User not found', function (t) {
+    var couchdb = mockCouchDbGetUser.reply(404, {error: 'Not Found'})
 
-    group.test('User found & Session valid', function (t) {
+    this.server.inject(routeOptions, function (response) {
+      t.is(couchdb.pendingMocks()[0], undefined, 'CouchDB received request')
+      t.is(response.statusCode, 401, 'returns 401 status')
+      t.is(response.result.errors.length, 1, 'returns one error')
+      t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Session invalid" error')
+      t.end()
+    })
+  })
+
+  group.test('User found', function (subGroup) {
+    subGroup.test('Session valid', function (t) {
       mockCouchDbGetUser.reply(200, {
         name: 'pat-doe',
         roles: [
           'id:userid123', 'mycustomrole'
         ],
-        profile: {
-          fullName: 'pat Doe',
-          email: 'pat@example.com'
-        },
         salt: 'salt123'
       })
 
-      var options = defaultsDeep({
-        url: '/session?include=account.profile'
-      }, routeOptions)
+      var sessionResponse = require('../../fixtures/session-response.json')
 
-      var sessionWithProfileResponse = require('../../fixtures/session-with-profile-response.json')
-
-      server.inject(options, function (response) {
+      this.server.inject(routeOptions, function (response) {
         delete response.result.meta
         t.is(response.statusCode, 200, 'returns 200 status')
-
-        t.deepEqual(response.result, sessionWithProfileResponse, 'returns the right content')
+        t.deepEqual(response.result, sessionResponse, 'returns the right content')
         t.end()
       })
     })
 
-    group.end()
+    subGroup.test('Session invalid', function (t) {
+      mockCouchDbGetUser.reply(200, {
+        name: 'pat-doe',
+        roles: [
+          'id:userid123', 'mycustomrole'
+        ],
+        salt: 'salt123'
+      })
+
+      var requestOptions = defaultsDeep({
+        headers: {
+          // Token calculated with invalid salt (salt456)
+          authorization: 'Session cGF0LWRvZToxMjc1MDA6YMtzOJDSC7iTA4cB2kjfjqbfk1Y'
+        }
+      }, routeOptions)
+
+      this.server.inject(requestOptions, function (response) {
+        t.is(response.statusCode, 401, 'returns 401 status')
+        t.is(response.result.errors.length, 1, 'returns one error')
+        t.is(response.result.errors[0].title, 'Unauthorized', 'returns "Unauthorized" error')
+        t.is(response.result.errors[0].detail, 'Session invalid', 'returns "Session invalid" message')
+        t.end()
+      })
+    })
+
+    subGroup.end()
   })
+
+  group.test('User is admin', function (t) {
+    var requestOptions = defaultsDeep({
+      headers: {
+        // calculateSessionId('admin', '1081b31861bd1e91611341da16c11c16a12c13718d1f712e', 'secret', 1209600)
+        authorization: 'Session YWRtaW46MTI3NTAwOh08V1EljPqAPAnv8mtxWNF87zdW'
+      }
+    }, routeOptions)
+
+    var sessionAdminResponse = require('../../fixtures/session-admin-response.json')
+
+    this.server.inject(requestOptions, function (response) {
+      delete response.result.meta
+      t.is(response.statusCode, 200, 'returns 200 status')
+      t.deepEqual(response.result, sessionAdminResponse, 'returns the right content')
+      t.end()
+    })
+  })
+
+  group.end()
+})
+
+test('GET /session?include=account.profile', function (group) {
+  group.beforeEach(getServer)
+
+  group.test('User found & Session valid', function (t) {
+    mockCouchDbGetUser.reply(200, {
+      name: 'pat-doe',
+      roles: [
+        'id:userid123', 'mycustomrole'
+      ],
+      profile: {
+        fullName: 'pat Doe',
+        email: 'pat@example.com'
+      },
+      salt: 'salt123'
+    })
+
+    var options = defaultsDeep({
+      url: '/session?include=account.profile'
+    }, routeOptions)
+
+    var sessionWithProfileResponse = require('../../fixtures/session-with-profile-response.json')
+
+    this.server.inject(options, function (response) {
+      delete response.result.meta
+      t.is(response.statusCode, 200, 'returns 200 status')
+
+      t.deepEqual(response.result, sessionWithProfileResponse, 'returns the right content')
+      t.end()
+    })
+  })
+
+  group.end()
 })
 
 test('GET /session?include=foobar', function (t) {
-  getServer(function (error, server) {
-    if (error) {
-      t.error(error)
-      t.end()
-      return
-    }
+  t.plan(2)
 
-    t.plan(1)
+  getServer(function (error, server) {
+    t.error(error)
 
     var options = defaultsDeep({
       url: '/session?include=foobar'

--- a/tests/integration/utils/authorization-header-not-allowed-error.js
+++ b/tests/integration/utils/authorization-header-not-allowed-error.js
@@ -1,16 +1,13 @@
 module.exports = authorizationHeaderNotAllowedError
 
-var merge = require('lodash/merge')
+var cloneDeep = require('lodash/cloneDeep')
 
-function authorizationHeaderNotAllowedError (server, group, routeOptions) {
-  var options = merge({}, routeOptions, {
-    headers: {
-      authorization: 'Session sessionid123'
-    }
-  })
-
+function authorizationHeaderNotAllowedError (group, routeOptions) {
   group.test('Authorization header provided', function (t) {
-    server.inject(options, function (response) {
+    var options = cloneDeep(routeOptions)
+    options.headers.authorization = 'Session sessionid123'
+
+    this.server.inject(options, function (response) {
       t.is(response.statusCode, 403, 'returns 403 status')
       t.is(response.result.errors.length, 1, 'returns one error')
       t.is(response.result.errors[0].title, 'Forbidden', 'returns "Forbidden" error')

--- a/tests/integration/utils/couchdb-error-tests.js
+++ b/tests/integration/utils/couchdb-error-tests.js
@@ -1,11 +1,11 @@
 module.exports = couchdbErrorTests
 
-function couchdbErrorTests (server, group, couchdbMock, routeOptions) {
+function couchdbErrorTests (group, couchdbMock, routeOptions) {
   // skipped, see https://github.com/pouchdb/pouchdb/issues/4658
   group.test('CouchDB not reachable', {skip: true}, function (t) {
     couchdbMock().replyWithError('Ooops')
 
-    server.inject(routeOptions, function (response) {
+    this.server.inject(routeOptions, function (response) {
       t.is(response.statusCode, 500, 'returns 500 status')
       t.is(response.result.errors.length, 1, 'returns one error')
       t.is(response.result.errors[0].title, 'Internal Server Error', 'returns "Internal Server Error" error')
@@ -19,7 +19,7 @@ function couchdbErrorTests (server, group, couchdbMock, routeOptions) {
       .socketDelay(10001)
       .reply(201)
 
-    server.inject(routeOptions, function (response) {
+    this.server.inject(routeOptions, function (response) {
       t.is(response.statusCode, 500, 'returns 500 status')
       t.is(response.result.errors.length, 1, 'returns one error')
       t.is(response.result.errors[0].title, 'Internal Server Error', 'returns "Internal Server Error" error')
@@ -27,25 +27,10 @@ function couchdbErrorTests (server, group, couchdbMock, routeOptions) {
     })
   })
 
-  // what are we testing here?
-  // group.test('CouchDB returns 418 error', function (t) {
-  //   couchdbMock().reply(418, {
-  //     error: 'teapot',
-  //     reason: 'too hot'
-  //   })
-  //
-  //   server.inject(routeOptions, function (response) {
-  //     t.is(response.statusCode, 418, 'returns 418 status')
-  //     t.is(response.result.errors.length, 1, 'returns one error')
-  //     t.is(response.result.errors[0].title, 'I\'m a teapot', 'returns "I\'m a teapot" error')
-  //     t.end()
-  //   })
-  // })
-
   group.test('CouchDB Server Error', {skip: true}, function (t) {
     couchdbMock().reply(500, 'Ooops')
 
-    server.inject(routeOptions, function (response) {
+    this.server.inject(routeOptions, function (response) {
       t.is(response.statusCode, 500, 'returns 500 status')
       t.is(response.result.errors.length, 1, 'returns one error')
       t.is(response.result.errors[0].title, 'Internal Server Error', 'returns "Internal Server Error" error')

--- a/tests/integration/utils/get-server.js
+++ b/tests/integration/utils/get-server.js
@@ -19,7 +19,7 @@ function getServer (options, callback) {
     callback = options
     options = {}
   }
-  var server = new Hapi.Server({
+  var server = this.server = new Hapi.Server({
     // easy debug!
     // debug: {
     //   request: ['error'],
@@ -30,7 +30,9 @@ function getServer (options, callback) {
 
   nock('http://localhost:5984')
     // PouchDB sends a request to see if db exists
-    .get('/_users/')
+    // no idea why .twice is needed here but without it put-account-test.js fails
+    // with very weird errors. Probably some race condition :/
+    .get('/_users/').twice()
     .query({})
     .reply(200, {db_name: '_users'})
     // design docs

--- a/tests/integration/utils/invalid-type-errors.js
+++ b/tests/integration/utils/invalid-type-errors.js
@@ -1,13 +1,13 @@
-var lodash = require('lodash')
+var cloneDeep = require('lodash/cloneDeep')
 
 module.exports = invalidTypeErrors
 
-function invalidTypeErrors (server, group, routeOptions, type) {
-  var options = lodash.cloneDeep(routeOptions)
-  delete options.payload.data.type
-
+function invalidTypeErrors (group, routeOptions, type) {
   group.test('type is not provided', function (t) {
-    server.inject(options, function (response) {
+    var options = cloneDeep(routeOptions)
+    delete options.payload.data.type
+
+    this.server.inject(options, function (response) {
       t.is(response.statusCode, 409, 'returns 409 status')
       t.is(response.result.errors.length, 1, 'returns one error')
       t.is(response.result.errors[0].title, 'Conflict', 'returns "Conflict" error')
@@ -17,9 +17,10 @@ function invalidTypeErrors (server, group, routeOptions, type) {
   })
 
   group.test('type is not supported', function (t) {
+    var options = cloneDeep(routeOptions)
     options.payload.data.type = 'foo'
 
-    server.inject(options, function (response) {
+    this.server.inject(options, function (response) {
       t.is(response.statusCode, 409, 'returns 409 status')
       t.is(response.result.errors.length, 1, 'returns one error')
       t.is(response.result.errors[0].title, 'Conflict', 'returns "Conflict" error')


### PR DESCRIPTION
The reason why the test fail is that the new version of `@hoodie/account-server-api` now caches accounts instead of requesting them from the database each time. The way we currently implement our routes test are not atomic, several tests share one server instance. 

closes #248