### PR TITLE
docs: Update License Year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2012-2016 the Hoodie Community and other contributors.
+   Copyright 2012-2017 the Hoodie Community and other contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
https://github.com/hoodiehq/camp/issues/108 updates the license year to 2012-2017

Can someone review? 
cc: @agonzalez0515 